### PR TITLE
Update Gemini Pro model

### DIFF
--- a/journal.py
+++ b/journal.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 app = typer.Typer(no_args_is_help=True)
 
 # Use the correct Gemini model name directly
-model_to_use = "gemini-2.5-pro-preview-06-05"
+model_to_use = "gemini-2.5-pro"
 
 
 # Annoying, ell can't take a base64 input of a file, lets use gemini raw for that

--- a/langchain_helper.py
+++ b/langchain_helper.py
@@ -185,7 +185,7 @@ def get_model(
         from langchain_google_genai import ChatGoogleGenerativeAI
         api_key = os.getenv("GOOGLE_API_KEY", "DUMMY_KEY")
         model = ChatGoogleGenerativeAI(
-            model="gemini-2.5-pro-preview-06-05", google_api_key=api_key
+            model="gemini-2.5-pro", google_api_key=api_key
         )
     elif google_flash:
         from langchain_google_genai import ChatGoogleGenerativeAI

--- a/prd/life-insights.md
+++ b/prd/life-insights.md
@@ -1,11 +1,11 @@
 The user created a bunch of journal entries, and then we sent to a phychiatrist for reports, the reports are generated and stored in
 
-~/tmp/monthly/2016-02-01_gemini-2.5-pro-preview-06-05.json
+~/tmp/monthly/2016-02-01_gemini-2.5-pro.json
 
-2016-02-01_gemini-2.5-pro-preview-06-05.json 2020-10-01_gemini-2.5-pro-preview-06-05.json 2025-05-30_gemini-2.5-pro-preview-06-05.json
-2016-02-29_gemini-2.5-pro-preview-06-05.json 2020-11-01_gemini-2.5-pro-preview-06-05.json 2025-06-20_gemini-2.5-pro-preview-06-05.json
-2016-03-31_gemini-2.5-pro-preview-06-05.json 2020-12-01_gemini-2.5-pro-preview-06-05.json 2025-06-22_gemini-2.5-pro-preview-06-05.json
-2016-04-24_gemini-2.5-pro-preview-06-05.json 2020-12-30_gemini-2.5-pro-preview-06-05.json 2099-01-01_gemini-2.5-pro-preview-06-05.json
+2016-02-01_gemini-2.5-pro.json 2020-10-01_gemini-2.5-pro.json 2025-05-30_gemini-2.5-pro.json
+2016-02-29_gemini-2.5-pro.json 2020-11-01_gemini-2.5-pro.json 2025-06-20_gemini-2.5-pro.json
+2016-03-31_gemini-2.5-pro.json 2020-12-01_gemini-2.5-pro.json 2025-06-22_gemini-2.5-pro.json
+2016-04-24_gemini-2.5-pro.json 2020-12-30_gemini-2.5-pro.json 2099-01-01_gemini-2.5-pro.json
 
 ➜ monthly pwd
 


### PR DESCRIPTION
## Summary
- update Gemini Pro model selection to `gemini-2.5-pro`
- fix journal example to reference new model
- update docs mentioning old model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687665c4584483209e95d5f0bc1388df