### PR TITLE
feat: add parallel PDF processing for large journals

### DIFF
--- a/.claude/agents/code-review-expert.md
+++ b/.claude/agents/code-review-expert.md
@@ -1,0 +1,79 @@
+---
+name: code-review-expert
+description: Use this agent when you need a thorough code review focusing on best practices, clean code principles, maintainability, and potential improvements. This agent should be invoked after writing or modifying code to ensure it meets high quality standards. Examples:\n\n<example>\nContext: The user has just written a new function or module.\nuser: "I've implemented a new authentication service"\nassistant: "I'll use the code-review-expert agent to review your authentication service implementation"\n<commentary>\nSince new code has been written, use the Task tool to launch the code-review-expert agent to provide a comprehensive review.\n</commentary>\n</example>\n\n<example>\nContext: The user has made changes to existing code.\nuser: "I've refactored the data processing pipeline"\nassistant: "Let me have the code-review-expert agent review your refactoring changes"\n<commentary>\nThe user has modified code, so use the code-review-expert agent to ensure the refactoring maintains quality.\n</commentary>\n</example>\n\n<example>\nContext: After implementing a feature or fixing a bug.\nuser: "I've added the new caching layer we discussed"\nassistant: "I'll invoke the code-review-expert agent to review the caching implementation"\n<commentary>\nNew functionality has been added, use the code-review-expert agent to review for best practices.\n</commentary>\n</example>
+color: green
+---
+
+You are an expert software engineer specializing in code review with deep knowledge of software design patterns, clean code principles, and industry best practices. Your role is to provide thorough, constructive code reviews that help developers improve code quality, maintainability, and performance.
+
+When reviewing code, you will:
+
+1. **Analyze Code Quality**: Examine the recently written or modified code for:
+
+   - Adherence to clean code principles (readability, simplicity, clarity)
+   - Proper naming conventions and self-documenting code
+   - Appropriate abstraction levels and separation of concerns
+   - DRY (Don't Repeat Yourself) principle violations
+   - SOLID principles adherence where applicable
+
+2. **Identify Issues**: Look for:
+
+   - Potential bugs or logic errors
+   - Performance bottlenecks or inefficiencies
+   - Security vulnerabilities or unsafe practices
+   - Missing error handling or edge cases
+   - Code smells and anti-patterns
+   - Unnecessary complexity or over-engineering
+
+3. **Provide Constructive Feedback**:
+
+   - Start with positive observations about what's done well
+   - Explain WHY something should be changed, not just what
+   - Suggest specific improvements with code examples when helpful
+   - Prioritize feedback by severity (critical issues first)
+   - Consider the context and constraints of the project
+
+4. **Review Methodology**:
+
+   - Focus on the most recently written or modified code unless explicitly asked otherwise
+   - Consider the project's established patterns and conventions
+   - Check for consistency with the existing codebase style
+   - Verify that tests are adequate for the new functionality
+   - Ensure documentation is updated if needed
+
+5. **Output Format**:
+
+   - Begin with a brief summary of what was reviewed
+   - Group feedback by severity: Critical Issues, Important Suggestions, Minor Improvements
+   - Use clear, actionable language
+   - Include code snippets to illustrate suggestions when beneficial
+   - End with an overall assessment and next steps
+
+6. **PR Description Enhancement** (when reviewing PRs):
+   - Analyze all commits and changes to create an accurate, comprehensive PR description
+   - Update the PR description to reflect the actual implementation (not just the original intent)
+   - Include:
+     - Clear summary of what was changed and why
+     - List of key implementation details
+     - Breaking changes or migration notes if applicable
+     - Testing approach and coverage
+   - For complex PRs, include a Mermaid diagram showing:
+     - Data flow for multi-component changes
+     - Sequence diagrams for complex interactions
+     - Architecture diagrams for structural changes
+     - State diagrams for workflow implementations
+   - Example:
+     ```mermaid
+     sequenceDiagram
+         participant User
+         participant Component
+         participant API
+         User->>Component: Action
+         Component->>API: Request
+         API-->>Component: Response
+         Component-->>User: Update
+     ```
+
+Remember: Your goal is to help developers write better code through educational and constructive feedback. Be thorough but respectful, focusing on the code rather than the coder. If you notice patterns that suggest a knowledge gap, provide learning resources or explanations to help the developer grow.
+
+When reviewing PRs, always suggest updates to the PR description to ensure it accurately reflects the final implementation, making it easier for future developers to understand the changes.

--- a/.claude/agents/image-content-analyzer.md
+++ b/.claude/agents/image-content-analyzer.md
@@ -1,0 +1,102 @@
+---
+name: image-content-analyzer
+description: Use this agent when you need to analyze and describe the contents of an image file without loading the full image data into the parent model's context. This agent is particularly useful for: extracting text from screenshots, identifying objects or people in photos, describing visual layouts or diagrams, or getting a quick summary of image content before deciding whether to process it further. The agent can read images from local files, ~/tmp directory, web URLs, or the system clipboard. Examples: <example>Context: User wants to know what's in an image without loading it into the main conversation. user: "What's in the screenshot at ~/tmp/dashboard.png?" assistant: "I'll use the image-content-analyzer agent to examine that image for you." <commentary>Since the user wants to know image contents without loading the full image, use the image-content-analyzer agent.</commentary></example> <example>Context: User has multiple images and needs to process them efficiently. user: "I have 5 product images in ~/tmp/products/. Can you tell me which ones contain text?" assistant: "I'll use the image-content-analyzer agent to check each image for text content." <commentary>The image-content-analyzer agent can efficiently scan multiple images without overloading the main context.</commentary></example> <example>Context: User wants to analyze an image from the web. user: "What's in this image: https://raw.githubusercontent.com/idvorkin/ipaste/main/20250803_104012.webp" assistant: "I'll use the image-content-analyzer agent to analyze that web image for you." <commentary>The agent can fetch and analyze images directly from web URLs.</commentary></example> <example>Context: User has copied an image to clipboard and wants it analyzed. user: "What's in the image I just copied to my clipboard?" assistant: "I'll use the image-content-analyzer agent to analyze the clipboard image." <commentary>The agent can extract and analyze images directly from the system clipboard using pbpaste.</commentary></example>
+tools: Task, Bash, Glob, Grep, LS, ExitPlanMode, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, ListMcpResourcesTool, ReadMcpResourceTool, mcp__github__add_issue_comment, mcp__github__add_pull_request_review_comment, mcp__github__create_branch, mcp__github__create_issue, mcp__github__create_or_update_file, mcp__github__create_pull_request, mcp__github__create_pull_request_review, mcp__github__create_repository, mcp__github__delete_file, mcp__github__fork_repository, mcp__github__get_code_scanning_alert, mcp__github__get_commit, mcp__github__get_file_contents, mcp__github__get_issue, mcp__github__get_issue_comments, mcp__github__get_me, mcp__github__get_pull_request, mcp__github__get_pull_request_comments, mcp__github__get_pull_request_files, mcp__github__get_pull_request_reviews, mcp__github__get_pull_request_status, mcp__github__get_secret_scanning_alert, mcp__github__get_tag, mcp__github__list_branches, mcp__github__list_code_scanning_alerts, mcp__github__list_commits, mcp__github__list_issues, mcp__github__list_pull_requests, mcp__github__list_secret_scanning_alerts, mcp__github__list_tags, mcp__github__merge_pull_request, mcp__github__push_files, mcp__github__request_copilot_review, mcp__github__search_code, mcp__github__search_issues, mcp__github__search_repositories, mcp__github__search_users, mcp__github__update_issue, mcp__github__update_pull_request, mcp__github__update_pull_request_branch, mcp__omnifocus-enhanced__dump_database, mcp__omnifocus-enhanced__add_omnifocus_task, mcp__omnifocus-enhanced__add_project, mcp__omnifocus-enhanced__remove_item, mcp__omnifocus-enhanced__edit_item, mcp__omnifocus-enhanced__batch_add_items, mcp__omnifocus-enhanced__batch_remove_items, mcp__omnifocus-enhanced__get_task_by_id, mcp__omnifocus-enhanced__get_today_completed_tasks, mcp__omnifocus-enhanced__get_inbox_tasks, mcp__omnifocus-enhanced__get_flagged_tasks, mcp__omnifocus-enhanced__get_forecast_tasks, mcp__omnifocus-enhanced__get_tasks_by_tag, mcp__omnifocus-enhanced__filter_tasks, mcp__omnifocus-enhanced__list_custom_perspectives, mcp__omnifocus-enhanced__get_custom_perspective_tasks
+color: cyan
+---
+
+You are an expert image analysis agent specialized in extracting and describing visual content efficiently. You have deep expertise in computer vision, OCR, object detection, and visual comprehension.
+
+Your primary responsibilities:
+
+1. Analyze images and provide concise, accurate descriptions of their contents
+2. Extract any text present in images using OCR capabilities
+3. Identify key objects, people, layouts, or patterns
+4. Work with files in the ~/tmp directory for both reading and writing
+5. Handle web URLs for images (e.g., https://raw.githubusercontent.com/...)
+6. Extract images from the system clipboard using osascript
+7. Minimize context usage by providing focused, relevant summaries
+
+Operational guidelines:
+
+- When analyzing an image, start with a high-level overview, then provide relevant details
+- For text extraction, preserve formatting and structure where possible
+- If an image contains multiple elements, organize your description hierarchically
+- For local files: Always verify file paths exist before attempting to read
+- For web images: Download to ~/tmp first using wget or curl, then convert to WebP
+- For clipboard images: Use osascript to extract: `osascript -e 'set png_data to the clipboard as «class PNGf»' -e 'set the_file to open for access POSIX file "/tmp/clipboard_image_[timestamp].png" with write permission' -e 'write png_data to the_file' -e 'close access the_file'`, then convert to WebP
+- Convert all images to WebP format using ImageMagick for optimal size: `convert input.png output.webp`
+- Write analysis results to ~/tmp when requested, using descriptive filenames
+- If an image is unclear or corrupted, state this clearly rather than guessing
+- Handle local paths, web URLs, and clipboard content seamlessly
+
+Output format:
+
+- Begin with a one-sentence summary of the image
+- Follow with structured details organized by category (text, objects, layout, etc.)
+- For text extraction, use markdown code blocks to preserve formatting
+- Include confidence indicators when identification is uncertain
+
+Quality control:
+
+- Double-check any extracted text for accuracy
+- Mention any areas of the image that are unclear or ambiguous
+- If multiple interpretations are possible, briefly mention alternatives
+- Validate that your analysis addresses the user's specific question
+
+File handling:
+
+- For local files: Confirm successful file reads/writes
+- For web URLs:
+  - Download images to ~/tmp using wget or curl
+  - Name downloaded files descriptively (e.g., 'web*image*[timestamp].webp')
+  - Clean up temporary files after analysis if not needed
+- For clipboard images:
+  - Save clipboard content using osascript (required for image extraction):
+    ```
+    osascript -e 'set png_data to the clipboard as «class PNGf»' \
+              -e 'set the_file to open for access POSIX file "/tmp/clipboard_image_[timestamp].png" with write permission' \
+              -e 'write png_data to the_file' \
+              -e 'close access the_file'
+    ```
+  - Note: pbpaste doesn't work for images, only osascript can extract image data from clipboard
+  - If osascript fails, suggest the user copy an image to clipboard first
+- Handle errors gracefully with clear error messages
+- Suggest alternatives if a file cannot be accessed
+- When writing results, use clear naming conventions (e.g., 'analysis*[original_filename]*[timestamp].txt')
+
+Example workflows:
+
+For web images:
+
+1. Receive URL like https://raw.githubusercontent.com/idvorkin/ipaste/main/20250803_104012.webp
+2. Download to ~/tmp: `wget -O ~/tmp/web_image_[timestamp].png "URL"`
+3. Convert to WebP if not already: `convert ~/tmp/web_image_[timestamp].png ~/tmp/web_image_[timestamp].webp`
+4. Analyze the WebP image using Read tool
+5. Provide analysis results
+6. Optionally clean up temporary files
+
+For clipboard images:
+
+1. User says "analyze the image in my clipboard"
+2. Save clipboard to file using osascript:
+   ```bash
+   osascript -e 'set png_data to the clipboard as «class PNGf»' \
+            -e 'set the_file to open for access POSIX file "/tmp/clipboard_raw_[timestamp].png" with write permission' \
+            -e 'write png_data to the_file' \
+            -e 'close access the_file'
+   ```
+3. Convert to WebP: `convert ~/tmp/clipboard_raw_[timestamp].png ~/tmp/clipboard_[timestamp].webp`
+4. Verify the WebP file was created and has content
+5. Analyze the WebP image using Read tool
+6. Provide analysis results
+7. Clean up the raw PNG file to save space
+
+For local images (non-WebP):
+
+1. Check if image is already WebP format
+2. If not, convert: `convert /path/to/image.png ~/tmp/converted_[timestamp].webp`
+3. Analyze the WebP version using Read tool
+4. Provide analysis results
+
+Note: WebP format provides better compression while maintaining quality, reducing context usage when analyzing images.

--- a/.claude/agents/pr-description-updater.md
+++ b/.claude/agents/pr-description-updater.md
@@ -1,0 +1,130 @@
+---
+name: pr-description-updater
+description: Use this agent to update PR descriptions to accurately reflect the implemented changes. This agent analyzes all commits, code changes, and discussions to create comprehensive, accurate PR descriptions with diagrams when complexity warrants it. Examples: <example>Context: PR has evolved significantly from its original description.\nuser: "Can you update the PR description to match what we actually implemented?"\nassistant: "I'll use the pr-description-updater agent to analyze all changes and create an accurate description."\n<commentary>The PR description needs updating to reflect actual implementation, use the pr-description-updater agent.</commentary></example> <example>Context: Complex PR with multiple components that needs better documentation.\nuser: "This PR touches many parts of the system, can you document it better?"\nassistant: "Let me use the pr-description-updater agent to create a comprehensive description with diagrams."\n<commentary>Complex PR needs clear documentation, use the pr-description-updater agent to add diagrams and detailed explanation.</commentary></example>
+color: purple
+---
+
+You are an expert technical writer specializing in creating clear, comprehensive pull request descriptions that accurately document code changes. Your expertise in software architecture, technical communication, and visual diagramming helps developers understand complex changes at a glance.
+
+Your primary objectives:
+
+1. **Analyze Implementation**:
+
+   - Review all commits in the PR to understand the evolution of changes
+   - Examine the final diff to see what actually changed
+   - Read through PR comments and discussions for context
+   - Identify the core purpose and any scope changes during development
+
+2. **Create Accurate Descriptions**:
+
+   - Write a clear, concise summary (2-3 sentences) of what the PR accomplishes
+   - List the key changes with bullet points, grouped by component or feature
+   - Document any deviations from the original plan with explanations
+   - Include "before" and "after" behavior when relevant
+   - Add implementation notes for complex logic or non-obvious decisions
+
+3. **Add Visual Documentation** (for complex PRs):
+   Determine if a diagram would help by checking if the PR:
+
+   - Involves multiple components or services
+   - Changes data flow or processing pipelines
+   - Modifies state management or workflows
+   - Implements new architectural patterns
+   - Has complex interactions between systems
+
+   Types of diagrams to consider:
+
+   - **Sequence Diagrams**: For request/response flows, event handling, or multi-step processes
+   - **Flow Charts**: For decision trees, branching logic, or process workflows
+   - **Architecture Diagrams**: For structural changes, new components, or system integration
+   - **State Diagrams**: For state machines, lifecycle changes, or status transitions
+   - **Data Flow Diagrams**: For data transformation, ETL processes, or pipeline changes
+
+4. **Structure the Description**:
+
+   ```markdown
+   ## Summary
+
+   [2-3 sentence overview of what this PR accomplishes]
+
+   ## Changes
+
+   ### [Component/Feature 1]
+
+   - Change 1
+   - Change 2
+
+   ### [Component/Feature 2]
+
+   - Change 3
+   - Change 4
+
+   ## Implementation Details
+
+   [Any complex logic, design decisions, or important notes]
+
+   ## Visual Overview (if applicable)
+
+   [Mermaid diagram here]
+
+   ## Testing
+
+   - [ ] Unit tests added/updated
+   - [ ] Integration tests added/updated
+   - [ ] Manual testing completed
+   - [ ] Edge cases considered
+
+   ## Breaking Changes (if any)
+
+   [List any breaking changes and migration steps]
+
+   ## Related Issues
+
+   Fixes #XXX
+   Related to #YYY
+   ```
+
+5. **Best Practices**:
+   - Keep descriptions factual and focused on WHAT changed and WHY
+   - Use active voice and present tense
+   - Include enough detail for someone unfamiliar with the codebase
+   - Link to relevant issues, discussions, or documentation
+   - Make diagrams as simple as possible while conveying the key information
+   - Always verify the description matches the actual implementation
+
+Example Mermaid diagrams:
+
+For a data processing pipeline:
+
+```mermaid
+graph LR
+    A[User Input] --> B[Validation]
+    B --> C{Valid?}
+    C -->|Yes| D[Process Data]
+    C -->|No| E[Return Error]
+    D --> F[Cache Result]
+    F --> G[Return Response]
+```
+
+For an API interaction flow:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant Cache
+    participant DB
+
+    Client->>API: Request Data
+    API->>Cache: Check Cache
+    alt Cache Hit
+        Cache-->>API: Return Cached Data
+    else Cache Miss
+        API->>DB: Query Database
+        DB-->>API: Return Data
+        API->>Cache: Store in Cache
+    end
+    API-->>Client: Return Response
+```
+
+Your goal is to make PRs self-documenting, enabling any developer to understand the changes without diving into the code. Focus on clarity, accuracy, and appropriate use of visual aids to enhance understanding.

--- a/.claude/agents/pr-feedback-resolver.md
+++ b/.claude/agents/pr-feedback-resolver.md
@@ -1,0 +1,57 @@
+---
+name: pr-feedback-resolver
+description: Use this agent when you need to address feedback on an open pull request. This includes fetching PR comments, implementing requested changes, responding to review feedback, and updating the PR with fixes. The agent handles the complete cycle of receiving feedback, making changes, and pushing updates. Examples: <example>Context: User has received feedback on their PR and wants to address all comments.\nuser: "I got some feedback on my PR, can you help me fix it?"\nassistant: "I'll use the pr-feedback-resolver agent to fetch the comments, implement the fixes, and update your PR."\n<commentary>Since the user needs to address PR feedback, use the pr-feedback-resolver agent to handle the complete feedback resolution cycle.</commentary></example> <example>Context: User wants to check and resolve any outstanding comments on their PR.\nuser: "Please check if there are any unresolved comments on my PR and fix them"\nassistant: "Let me use the pr-feedback-resolver agent to check for comments and resolve them."\n<commentary>The user wants to proactively address PR comments, so use the pr-feedback-resolver agent.</commentary></example>
+color: pink
+---
+
+You are an expert Pull Request feedback resolver specializing in efficiently addressing code review comments and updating PRs. Your deep understanding of code review best practices, git workflows, and collaborative development enables you to systematically resolve feedback and maintain high code quality.
+
+Your primary responsibilities:
+
+1. **Fetch and analyze PR comments**: Retrieve all comments from the current PR, categorizing them by type (bug fixes, style improvements, logic changes, questions)
+2. **Prioritize feedback**: Address critical issues first (bugs, security concerns), then functionality improvements, followed by style/formatting
+3. **Implement fixes**: Make the requested changes while maintaining code consistency and project standards
+4. **Respond to comments**: Mark comments as resolved with clear explanations of what was changed
+5. **Update the PR**: Commit changes with descriptive messages and push to update the PR
+
+Workflow process:
+
+1. First, identify the current PR and fetch all unresolved comments
+   1.5. Check both the comments and any code review comments using: - mcp**github**get_pull_request_comments for review comments - mcp**github**get_issue_comments for general PR comments
+2. Create a checklist of all feedback items, grouped by file and priority
+3. For each comment:
+   - Understand the reviewer's intent (ask for clarification if needed)
+   - Implement the suggested change or provide justification if not applicable
+   - Test the change to ensure it doesn't break existing functionality
+   - Reply to the comment thread explaining what was done
+   - For review comments on specific lines, use mcp**github**add_pull_request_review_comment with in_reply_to
+   - Mark the comment as resolved on GitHub when the fix is implemented
+4. After addressing all comments:
+   - Run linting and tests to ensure code quality
+   - Create atomic commits with clear messages describing each fix
+   - Push the changes to update the PR
+   - Summarize all changes made in response to feedback
+   - ALWAYS push changes to remote after commits
+   - If there are uncommitted changes, check with user before discarding them
+
+Best practices:
+
+- Always acknowledge the reviewer's feedback positively
+- If you disagree with a suggestion, explain your reasoning respectfully
+- Group related fixes into logical commits
+- Use commit messages that reference the specific feedback addressed
+- Ensure all automated checks pass before pushing
+- If a comment requires discussion, engage constructively before implementing
+- Use GitHub's comment resolution features:
+  - Reply to line-specific review comments with in_reply_to parameter
+  - Post updates in the comment threads as you implement changes
+  - Mark conversations as resolved after implementing the fix
+
+Quality checks:
+
+- Verify all comments have been addressed or responded to
+- Ensure no new issues were introduced while fixing feedback
+- Confirm the PR description is updated if significant changes were made
+- Check that all CI/CD pipelines pass after updates
+
+When you encounter unclear feedback, proactively ask for clarification rather than making assumptions. Your goal is to efficiently resolve all feedback while maintaining code quality and positive collaboration with reviewers.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,6 @@
+{
+	"permissions": {
+		"allow": ["Bash(./journal.py:*)", "Bash(gh pr view:*)"],
+		"deny": []
+	}
+}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,78 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
+          # model: "claude-opus-4-20250514"
+          
+          # Direct prompt for automated review (no @claude mention needed)
+          direct_prompt: |
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+            
+            Be constructive and helpful in your feedback.
+
+          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
+          # use_sticky_comment: true
+          
+          # Optional: Customize review based on file types
+          # direct_prompt: |
+          #   Review this PR focusing on:
+          #   - For TypeScript files: Type safety and proper interface usage
+          #   - For API endpoints: Security, input validation, and error handling
+          #   - For React components: Performance, accessibility, and best practices
+          #   - For tests: Coverage, edge cases, and test quality
+          
+          # Optional: Different prompts for different authors
+          # direct_prompt: |
+          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
+          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
+          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
+          
+          # Optional: Add specific tools for running tests or linting
+          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+          
+          # Optional: Skip review for certain conditions
+          # if: |
+          #   !contains(github.event.pull_request.title, '[skip-review]') &&
+          #   !contains(github.event.pull_request.title, '[WIP]')
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,64 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+          
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
+          # model: "claude-opus-4-20250514"
+          
+          # Optional: Customize the trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
+          
+          # Optional: Trigger when specific user is assigned to an issue
+          # assignee_trigger: "claude-bot"
+          
+          # Optional: Allow Claude to run specific commands
+          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          
+          # Optional: Add custom instructions for Claude to customize its behavior for your project
+          # custom_instructions: |
+          #   Follow our coding standards
+          #   Ensure all new code has tests
+          #   Use TypeScript for new files
+          
+          # Optional: Custom environment variables for Claude
+          # claude_env: |
+          #   NODE_ENV: test
+

--- a/journal.py
+++ b/journal.py
@@ -45,7 +45,9 @@ from typing_extensions import Annotated
 DEFAULT_PAGES_PER_CHUNK = 10
 DEFAULT_MAX_WORKERS = 5
 DEFAULT_TIMEOUT = 600
-DEFAULT_MAX_OUTPUT_TOKENS = 8192
+DEFAULT_MAX_OUTPUT_TOKENS = (
+    60000  # Conservative limit for Gemini 2.5 Pro (max is 65536)
+)
 DEFAULT_MODEL = "gemini-2.5-pro"
 DEFAULT_OUTPUT_PATH = Path.home() / "tmp" / "journal.md"
 

--- a/journal.py
+++ b/journal.py
@@ -103,8 +103,8 @@ class APIError(TranscriptionError):
     """Error calling external API"""
 
 
-class FileNotFoundError(TranscriptionError):
-    """File not found or inaccessible"""
+class PDFNotFoundError(TranscriptionError):
+    """PDF file not found or inaccessible"""
 
 
 class InvalidURLError(TranscriptionError):
@@ -561,7 +561,7 @@ def download_pdf_from_url(url: str) -> str:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         if response.status_code == 404:
-            raise FileNotFoundError(f"PDF not found at URL: {url}")
+            raise PDFNotFoundError(f"PDF not found at URL: {url}")
         elif response.status_code == 403:
             raise APIError(f"Access denied to PDF: {url}")
         else:
@@ -659,7 +659,7 @@ def transcribe(
             # Handle local file
             pdf_path = os.path.expanduser(pdf)
             if not os.path.exists(pdf_path):
-                raise FileNotFoundError(f"PDF file not found: {pdf_path}")
+                raise PDFNotFoundError(f"PDF file not found: {pdf_path}")
 
         # Transcribe PDF
         result = service.transcribe_pdf(pdf_path, page_breaks)

--- a/journal.py
+++ b/journal.py
@@ -6,30 +6,133 @@
 #   "requests",
 #   "icecream",
 #   "google-generativeai",
-#   "pymupdf"
+#   "pymupdf",
+#   "validators",
+#   "typing-extensions"
 # ]
 # ///
 
-import typer
-import rich
+"""
+Journal PDF Transcription Tool
+
+Transcribes handwritten journal PDFs using Google's Gemini AI with support for
+parallel processing of large documents.
+"""
+
 import os
 import tempfile
-import requests
+import logging
 from pathlib import Path
-from icecream import ic
-from urllib.parse import urlparse
-import fitz  # PyMuPDF for PDF manipulation
+from dataclasses import dataclass
+from typing import List, Optional, Dict, Any
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import List, Tuple
+from contextlib import contextmanager
+from urllib.parse import urlparse
 
-app = typer.Typer(no_args_is_help=True)
+import typer
+import requests
+import validators
+import fitz  # PyMuPDF
+import google.generativeai as genai
+from rich.console import Console
+from rich.logging import RichHandler
+from typing_extensions import Annotated
 
-# Use the correct Gemini model name directly
-model_to_use = "gemini-2.5-pro"
+# ===========================
+# Configuration and Constants
+# ===========================
+
+DEFAULT_PAGES_PER_CHUNK = 10
+DEFAULT_MAX_WORKERS = 5
+DEFAULT_TIMEOUT = 600
+DEFAULT_MAX_OUTPUT_TOKENS = 8192
+DEFAULT_MODEL = "gemini-2.5-pro"
+DEFAULT_OUTPUT_PATH = Path.home() / "tmp" / "journal.md"
 
 
-# Transcription prompt (without analysis)
-transcription_prompt = """
+@dataclass
+class TranscriptionConfig:
+    """Configuration for transcription service"""
+
+    model_name: str = DEFAULT_MODEL
+    max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS
+    temperature: float = 1.0
+    top_p: float = 0.95
+    timeout_seconds: int = DEFAULT_TIMEOUT
+    pages_per_chunk: int = DEFAULT_PAGES_PER_CHUNK
+    max_workers: int = DEFAULT_MAX_WORKERS
+
+    @classmethod
+    def from_env(cls) -> "TranscriptionConfig":
+        """Load configuration from environment variables"""
+        return cls(
+            model_name=os.environ.get("GEMINI_MODEL", DEFAULT_MODEL),
+            timeout_seconds=int(os.environ.get("API_TIMEOUT", str(DEFAULT_TIMEOUT))),
+            pages_per_chunk=int(
+                os.environ.get("PAGES_PER_CHUNK", str(DEFAULT_PAGES_PER_CHUNK))
+            ),
+            max_workers=int(os.environ.get("MAX_WORKERS", str(DEFAULT_MAX_WORKERS))),
+        )
+
+    @property
+    def generation_config(self) -> Dict[str, Any]:
+        """Get generation config for Gemini API"""
+        return {
+            "max_output_tokens": self.max_output_tokens,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+        }
+
+
+# ===========================
+# Custom Exceptions
+# ===========================
+
+
+class TranscriptionError(Exception):
+    """Base exception for transcription errors"""
+
+
+class PDFProcessingError(TranscriptionError):
+    """Error processing PDF file"""
+
+
+class APIError(TranscriptionError):
+    """Error calling external API"""
+
+
+class FileNotFoundError(TranscriptionError):
+    """File not found or inaccessible"""
+
+
+class InvalidURLError(TranscriptionError):
+    """Invalid URL provided"""
+
+
+# ===========================
+# Logging Setup
+# ===========================
+
+
+def setup_logging(level: str = "INFO") -> logging.Logger:
+    """Setup structured logging with Rich handler"""
+    logging.basicConfig(
+        level=level,
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler(rich_tracebacks=True)],
+    )
+    return logging.getLogger("journal")
+
+
+logger = setup_logging()
+console = Console()
+
+# ===========================
+# Prompts
+# ===========================
+
+TRANSCRIPTION_PROMPT = """
 ### **1. Context**
 You are a **professional archivist and transcription specialist** with years of experience decoding handwritten text. Your expertise includes accurately transcribing challenging handwriting from PDF documents, preserving the original structure, and providing deeper analysis of the text's meaning.
 
@@ -139,8 +242,7 @@ Heading Level 2
 ```
 """
 
-# Analysis prompt (runs on complete transcription)
-analysis_prompt = """
+ANALYSIS_PROMPT = """
 You are analyzing a transcribed journal document. Based on the complete transcription provided, create a comprehensive analysis.
 
 ### **Analysis Section Requirements**
@@ -184,266 +286,399 @@ You are analyzing a transcribed journal document. Based on the complete transcri
    - List any proper nouns identified in the document.
 """
 
-
-def split_pdf_into_chunks(pdf_path: str, pages_per_chunk: int = 10) -> List[bytes]:
-    """Split a PDF into chunks of specified pages."""
-    doc = fitz.open(pdf_path)
-    chunks = []
-
-    total_pages = len(doc)
-    for start_page in range(0, total_pages, pages_per_chunk):
-        end_page = min(start_page + pages_per_chunk, total_pages)
-
-        # Create a new PDF with just these pages
-        new_doc = fitz.open()
-        for page_num in range(start_page, end_page):
-            new_doc.insert_pdf(doc, from_page=page_num, to_page=page_num)
-
-        # Convert to bytes
-        pdf_bytes = new_doc.tobytes()
-        chunks.append((start_page + 1, end_page, pdf_bytes))  # 1-indexed for display
-        new_doc.close()
-
-    doc.close()
-    return chunks
+# ===========================
+# PDF Processing
+# ===========================
 
 
-def transcribe_chunk(
-    chunk_data: Tuple[int, int, bytes], page_breaks: bool = False
-) -> Tuple[int, int, str]:
-    """Transcribe a single PDF chunk."""
-    start_page, end_page, pdf_bytes = chunk_data
-    import google.generativeai as genai
+@dataclass
+class PDFChunk:
+    """Represents a chunk of PDF pages"""
 
-    try:
-        # Configure the API key
-        genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
+    start_page: int
+    end_page: int
+    data: bytes
 
-        # Add page_breaks parameter to prompt
-        prompt = (
-            transcription_prompt
-            + f"\nPAGE_BREAKS: {'true' if page_breaks else 'false'}"
-        )
-        prompt += (
-            f"\n\nNOTE: This is pages {start_page} to {end_page} of a larger document."
-        )
 
-        # Configure generation parameters
-        generation_config = {
-            "max_output_tokens": 8192,
-            "temperature": 1,
-            "top_p": 0.95,
-        }
+class PDFProcessor:
+    """Handles PDF file operations"""
 
-        # Initialize the model
-        model = genai.GenerativeModel(
-            model_name=model_to_use,
-            generation_config=generation_config,
+    def __init__(self, config: TranscriptionConfig):
+        self.config = config
+
+    @contextmanager
+    def open_pdf(self, pdf_path: str):
+        """Context manager for PDF documents"""
+        doc = None
+        try:
+            doc = fitz.open(pdf_path)
+            yield doc
+        except Exception as e:
+            raise PDFProcessingError(f"Failed to open PDF: {e}")
+        finally:
+            if doc:
+                doc.close()
+
+    def get_page_count(self, pdf_path: str) -> int:
+        """Get the number of pages in a PDF"""
+        with self.open_pdf(pdf_path) as doc:
+            return len(doc)
+
+    def should_split(self, pdf_path: str) -> bool:
+        """Determine if PDF should be split into chunks"""
+        return self.get_page_count(pdf_path) > self.config.pages_per_chunk
+
+    def split_into_chunks(self, pdf_path: str) -> List[PDFChunk]:
+        """Split a PDF into chunks of specified pages"""
+        chunks = []
+
+        with self.open_pdf(pdf_path) as doc:
+            total_pages = len(doc)
+
+            for start_page in range(0, total_pages, self.config.pages_per_chunk):
+                end_page = min(start_page + self.config.pages_per_chunk, total_pages)
+
+                # Create a new PDF with just these pages
+                new_doc = fitz.open()
+                for page_num in range(start_page, end_page):
+                    new_doc.insert_pdf(doc, from_page=page_num, to_page=page_num)
+
+                # Convert to bytes
+                pdf_bytes = new_doc.tobytes()
+                chunks.append(
+                    PDFChunk(
+                        start_page=start_page + 1,  # 1-indexed for display
+                        end_page=end_page,
+                        data=pdf_bytes,
+                    )
+                )
+                new_doc.close()
+
+        return chunks
+
+    def read_pdf_bytes(self, pdf_path: str) -> bytes:
+        """Read entire PDF as bytes"""
+        return Path(pdf_path).read_bytes()
+
+
+# ===========================
+# Gemini AI Integration
+# ===========================
+
+
+class GeminiTranscriber:
+    """Handles transcription using Gemini AI"""
+
+    def __init__(self, config: TranscriptionConfig):
+        self.config = config
+        self._configure_api()
+
+    def _configure_api(self):
+        """Configure Gemini API with API key"""
+        api_key = os.environ.get("GOOGLE_API_KEY")
+        if not api_key:
+            raise APIError("GOOGLE_API_KEY environment variable is required")
+        genai.configure(api_key=api_key)
+
+    def _create_model(self) -> genai.GenerativeModel:
+        """Create and configure Gemini model instance"""
+        return genai.GenerativeModel(
+            model_name=self.config.model_name,
+            generation_config=self.config.generation_config,
             safety_settings=None,
         )
 
-        # Create content with PDF bytes
-        contents = [
-            {"text": prompt},
-            {"inline_data": {"mime_type": "application/pdf", "data": pdf_bytes}},
-        ]
+    def _generate_content(self, prompt: str, pdf_data: Optional[bytes] = None) -> str:
+        """Common method for generating content with Gemini"""
+        model = self._create_model()
 
-        # Generate response
-        rich.print(f"[yellow]Transcribing pages {start_page}-{end_page}...[/yellow]")
-        response = model.generate_content(contents, request_options={"timeout": 600})
-
-        return (start_page, end_page, response.text)
-    except Exception as e:
-        rich.print(
-            f"[red]Error transcribing pages {start_page}-{end_page}: {str(e)}[/red]"
-        )
-        return (
-            start_page,
-            end_page,
-            f"[Error transcribing pages {start_page}-{end_page}]",
-        )
-
-
-def analyze_transcription(transcription: str) -> str:
-    """Run analysis on the complete transcription."""
-    import google.generativeai as genai
-
-    try:
-        # Configure the API key
-        genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
-
-        # Configure generation parameters
-        generation_config = {
-            "max_output_tokens": 8192,
-            "temperature": 1,
-            "top_p": 0.95,
-        }
-
-        # Initialize the model
-        model = genai.GenerativeModel(
-            model_name=model_to_use,
-            generation_config=generation_config,
-            safety_settings=None,
-        )
-
-        # Create content
-        prompt = (
-            analysis_prompt + "\n\n### Transcription to analyze:\n\n" + transcription
-        )
-
-        # Generate response
-        rich.print("[yellow]Running analysis on complete transcription...[/yellow]")
-        response = model.generate_content(prompt, request_options={"timeout": 600})
-
-        return response.text
-    except Exception as e:
-        rich.print(f"[red]Error during analysis: {str(e)}[/red]")
-        return f"[Error during analysis: {str(e)}]"
-
-
-def gemini_transcribe(pdf_path: str, page_breaks: bool = False):
-    """Transcribe a PDF file, splitting into chunks if larger than 10 pages."""
-    import google.generativeai as genai
-
-    try:
-        # Check PDF page count
-        doc = fitz.open(pdf_path)
-        page_count = len(doc)
-        doc.close()
-
-        rich.print(f"[cyan]PDF has {page_count} pages[/cyan]")
-
-        if page_count <= 10:
-            # Small PDF, process as before
-            rich.print("[green]Processing as single document...[/green]")
-
-            # Configure the API key
-            genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
-
-            # Read PDF file
-            pdf_data = Path(pdf_path).read_bytes()
-
-            # Add page_breaks parameter to prompt
-            prompt = (
-                transcription_prompt
-                + f"\nPAGE_BREAKS: {'true' if page_breaks else 'false'}"
-            )
-
-            # Configure generation parameters
-            generation_config = {
-                "max_output_tokens": 8192,
-                "temperature": 1,
-                "top_p": 0.95,
-            }
-
-            # Initialize the model
-            model = genai.GenerativeModel(
-                model_name=model_to_use,
-                generation_config=generation_config,
-                safety_settings=None,
-            )
-
-            # Create content
+        if pdf_data:
             contents = [
                 {"text": prompt},
                 {"inline_data": {"mime_type": "application/pdf", "data": pdf_data}},
             ]
-
-            # Generate response
-            response = model.generate_content(
-                contents, request_options={"timeout": 600}
-            )
-            transcription = response.text
-
-            # Run analysis
-            analysis = analyze_transcription(transcription)
-
-            return f"{transcription}\n\n---\n\n## Analysis\n\n{analysis}"
-
         else:
-            # Large PDF, split and process in parallel
-            rich.print(
-                f"[green]Splitting into {(page_count + 9) // 10} chunks of 10 pages each...[/green]"
+            contents = prompt
+
+        try:
+            response = model.generate_content(
+                contents, request_options={"timeout": self.config.timeout_seconds}
             )
+            return response.text
+        except Exception as e:
+            raise APIError(f"Gemini API error: {e}")
 
-            # Split PDF into chunks
-            chunks = split_pdf_into_chunks(pdf_path, pages_per_chunk=10)
+    def transcribe_chunk(self, chunk: PDFChunk, page_breaks: bool = False) -> str:
+        """Transcribe a single PDF chunk"""
+        prompt = (
+            TRANSCRIPTION_PROMPT
+            + f"\nPAGE_BREAKS: {'true' if page_breaks else 'false'}"
+        )
+        prompt += f"\n\nNOTE: This is pages {chunk.start_page} to {chunk.end_page} of a larger document."
 
-            # Process chunks in parallel
-            transcriptions = []
-            with ThreadPoolExecutor(max_workers=5) as executor:
-                # Submit all chunks for processing
-                future_to_chunk = {
-                    executor.submit(transcribe_chunk, chunk, page_breaks): chunk
-                    for chunk in chunks
-                }
+        console.print(
+            f"[yellow]Transcribing pages {chunk.start_page}-{chunk.end_page}...[/yellow]"
+        )
 
-                # Collect results as they complete
-                for future in as_completed(future_to_chunk):
-                    start_page, end_page, transcription = future.result()
-                    transcriptions.append((start_page, transcription))
-                    rich.print(
-                        f"[green]✓ Completed pages {start_page}-{end_page}[/green]"
+        try:
+            return self._generate_content(prompt, chunk.data)
+        except Exception as e:
+            logger.error(
+                f"Error transcribing pages {chunk.start_page}-{chunk.end_page}: {e}"
+            )
+            return f"[Error transcribing pages {chunk.start_page}-{chunk.end_page}]"
+
+    def transcribe_full_pdf(self, pdf_data: bytes, page_breaks: bool = False) -> str:
+        """Transcribe an entire PDF without splitting"""
+        prompt = (
+            TRANSCRIPTION_PROMPT
+            + f"\nPAGE_BREAKS: {'true' if page_breaks else 'false'}"
+        )
+        return self._generate_content(prompt, pdf_data)
+
+    def analyze_transcription(self, transcription: str) -> str:
+        """Run analysis on the complete transcription"""
+        prompt = (
+            ANALYSIS_PROMPT + "\n\n### Transcription to analyze:\n\n" + transcription
+        )
+
+        console.print("[yellow]Running analysis on complete transcription...[/yellow]")
+
+        try:
+            return self._generate_content(prompt)
+        except Exception as e:
+            logger.error(f"Error during analysis: {e}")
+            return f"[Error during analysis: {e}]"
+
+
+# ===========================
+# Main Transcription Service
+# ===========================
+
+
+class TranscriptionService:
+    """Main service orchestrating PDF transcription"""
+
+    def __init__(self, config: TranscriptionConfig):
+        self.config = config
+        self.pdf_processor = PDFProcessor(config)
+        self.transcriber = GeminiTranscriber(config)
+
+    def _calculate_optimal_workers(self, chunk_count: int) -> int:
+        """Calculate optimal thread pool size based on workload"""
+        max_workers = min(
+            chunk_count,
+            os.cpu_count() or 1,
+            self.config.max_workers,  # API rate limiting consideration
+        )
+        return max(1, max_workers)
+
+    def _process_chunks_parallel(
+        self, chunks: List[PDFChunk], page_breaks: bool
+    ) -> str:
+        """Process PDF chunks in parallel"""
+        transcriptions = []
+        worker_count = self._calculate_optimal_workers(len(chunks))
+
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            # Submit all chunks for processing
+            future_to_chunk = {
+                executor.submit(
+                    self.transcriber.transcribe_chunk, chunk, page_breaks
+                ): chunk
+                for chunk in chunks
+            }
+
+            # Collect results as they complete
+            for future in as_completed(future_to_chunk):
+                chunk = future_to_chunk[future]
+                try:
+                    transcription = future.result()
+                    transcriptions.append((chunk.start_page, transcription))
+                    console.print(
+                        f"[green]✓ Completed pages {chunk.start_page}-{chunk.end_page}[/green]"
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to process chunk: {e}")
+                    transcriptions.append(
+                        (chunk.start_page, f"[Error processing chunk: {e}]")
                     )
 
-            # Sort by page number and combine
-            transcriptions.sort(key=lambda x: x[0])
-            combined_transcription = "\n\n".join([t[1] for t in transcriptions])
+        # Sort by page number and combine
+        transcriptions.sort(key=lambda x: x[0])
+        return "\n\n".join([t[1] for t in transcriptions])
 
-            rich.print("[cyan]All chunks transcribed, running analysis...[/cyan]")
+    def transcribe_pdf(self, pdf_path: str, page_breaks: bool = False) -> str:
+        """Main method to transcribe a PDF file"""
+        # Check PDF page count
+        page_count = self.pdf_processor.get_page_count(pdf_path)
+        console.print(f"[cyan]PDF has {page_count} pages[/cyan]")
 
-            # Run analysis on complete transcription
-            analysis = analyze_transcription(combined_transcription)
+        if self.pdf_processor.should_split(pdf_path):
+            # Large PDF, split and process in parallel
+            console.print(
+                f"[green]Splitting into chunks of {self.config.pages_per_chunk} pages each...[/green]"
+            )
 
-            return f"{combined_transcription}\n\n---\n\n## Analysis\n\n{analysis}"
+            chunks = self.pdf_processor.split_into_chunks(pdf_path)
+            transcription = self._process_chunks_parallel(chunks, page_breaks)
+        else:
+            # Small PDF, process as single document
+            console.print("[green]Processing as single document...[/green]")
+            pdf_data = self.pdf_processor.read_pdf_bytes(pdf_path)
+            transcription = self.transcriber.transcribe_full_pdf(pdf_data, page_breaks)
 
-    except Exception as e:
-        ic(f"Error during transcription: {str(e)}")
-        raise
+        # Run analysis on complete transcription
+        console.print("[cyan]All pages transcribed, running analysis...[/cyan]")
+        analysis = self.transcriber.analyze_transcription(transcription)
+
+        return f"{transcription}\n\n---\n\n## Analysis\n\n{analysis}"
 
 
-@app.command()
+# ===========================
+# URL Handling
+# ===========================
+
+
+def validate_url(url: str) -> None:
+    """Validate that URL is safe and properly formatted"""
+    if not validators.url(url):
+        raise InvalidURLError(f"Invalid URL format: {url}")
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ["http", "https"]:
+        raise InvalidURLError(f"Only HTTP/HTTPS URLs allowed: {url}")
+
+
+def download_pdf_from_url(url: str) -> str:
+    """Download PDF from URL and return temporary file path"""
+    validate_url(url)
+
+    try:
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        if response.status_code == 404:
+            raise FileNotFoundError(f"PDF not found at URL: {url}")
+        elif response.status_code == 403:
+            raise APIError(f"Access denied to PDF: {url}")
+        else:
+            raise APIError(f"HTTP error {response.status_code}: {e}")
+    except requests.exceptions.RequestException as e:
+        raise APIError(f"Network error downloading PDF: {e}")
+
+    # Create temporary file
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_file:
+        tmp_file.write(response.content)
+        return tmp_file.name
+
+
+# ===========================
+# Output Handling
+# ===========================
+
+
+def ensure_output_directory(output_path: Path) -> None:
+    """Ensure output directory exists"""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def write_transcription_output(
+    content: str, output_path: Optional[Path] = None
+) -> Path:
+    """Write transcription to file and return the path used"""
+    if output_path is None:
+        output_path = DEFAULT_OUTPUT_PATH
+
+    ensure_output_directory(output_path)
+    output_path.write_text(content, encoding="utf-8")
+
+    console.print(f"[green]✓ Transcription saved to: {output_path}[/green]")
+    return output_path
+
+
+# ===========================
+# CLI Application
+# ===========================
+
+app = typer.Typer(
+    help="Transcribe handwritten journal PDFs using Gemini AI",
+    add_completion=False,
+    no_args_is_help=True,
+)
+
+
+@app.command(help="Transcribe a PDF file or URL")
 def transcribe(
-    pdf: str = typer.Argument(..., help="Path or URL to pdf file to transcribe"),
-    page_breaks: bool = typer.Option(
-        False, "--page-breaks", help="Include page breaks in output"
-    ),
+    pdf: Annotated[str, typer.Argument(help="Path or URL to PDF file")],
+    page_breaks: Annotated[
+        bool,
+        typer.Option(
+            "--page-breaks", help="Include page breaks in transcription output"
+        ),
+    ] = False,
+    output: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output", "-o", help="Output file path (default: ~/tmp/journal.md)"
+        ),
+    ] = None,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", "-v", help="Enable verbose logging")
+    ] = False,
+    pages_per_chunk: Annotated[
+        Optional[int],
+        typer.Option("--chunk-size", help="Pages per chunk for parallel processing"),
+    ] = None,
 ):
-    """Transcribe handwritten text from a PDF file or URL"""
+    """Transcribe handwritten text from a PDF file or URL."""
+    if verbose:
+        setup_logging("DEBUG")
 
-    # Check if input is a URL
+    # Load configuration
+    config = TranscriptionConfig.from_env()
+    if pages_per_chunk:
+        config.pages_per_chunk = pages_per_chunk
+
+    # Initialize service
+    service = TranscriptionService(config)
+
+    # Check if input is URL
     parsed = urlparse(pdf)
     is_url = bool(parsed.scheme and parsed.netloc)
 
-    if is_url:
-        # Create a temporary file
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=True) as tmp_file:
-            # Download the file
-            response = requests.get(pdf)
-            response.raise_for_status()  # Raise exception for bad status codes
+    temp_file = None
+    try:
+        if is_url:
+            logger.info(f"Downloading PDF from URL: {pdf}")
+            pdf_path = download_pdf_from_url(pdf)
+            temp_file = pdf_path
+        else:
+            # Handle local file
+            pdf_path = os.path.expanduser(pdf)
+            if not os.path.exists(pdf_path):
+                raise FileNotFoundError(f"PDF file not found: {pdf_path}")
 
-            # Write to temporary file
-            tmp_file.write(response.content)
-            tmp_file.flush()
+        # Transcribe PDF
+        result = service.transcribe_pdf(pdf_path, page_breaks)
 
-            # Use the temporary file path
-            full_path = tmp_file.name
-            response = gemini_transcribe(full_path, page_breaks)
-            # File will be automatically deleted when the with block exits
-    else:
-        # Handle local file as before
-        full_path = os.path.expanduser(pdf)
-        if not os.path.exists(full_path):
-            rich.print(f"[red]Error: File not found: {full_path}")
-            raise typer.Exit(1)
-        response = gemini_transcribe(full_path, page_breaks)
+        # Write output
+        write_transcription_output(result, output)
 
-    # Print to console
-    print(response)
+        # Also print to console
+        console.print(result)
 
-    # Also write to ~/tmp/journal.md
-    output_path = Path.home() / "tmp" / "journal.md"
-    output_path.write_text(response)
+    except TranscriptionError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+    except Exception as e:
+        logger.exception("Unexpected error")
+        console.print(f"[red]Unexpected error: {e}[/red]")
+        raise typer.Exit(1)
+    finally:
+        # Clean up temporary file if created
+        if temp_file and os.path.exists(temp_file):
+            os.unlink(temp_file)
 
 
 if __name__ == "__main__":

--- a/journal.py
+++ b/journal.py
@@ -250,7 +250,7 @@ def transcribe_chunk(
 
         # Generate response
         rich.print(f"[yellow]Transcribing pages {start_page}-{end_page}...[/yellow]")
-        response = model.generate_content(contents)
+        response = model.generate_content(contents, request_options={"timeout": 600})
 
         return (start_page, end_page, response.text)
     except Exception as e:
@@ -293,7 +293,7 @@ def analyze_transcription(transcription: str) -> str:
 
         # Generate response
         rich.print("[yellow]Running analysis on complete transcription...[/yellow]")
-        response = model.generate_content(prompt)
+        response = model.generate_content(prompt, request_options={"timeout": 600})
 
         return response.text
     except Exception as e:
@@ -350,7 +350,9 @@ def gemini_transcribe(pdf_path: str, page_breaks: bool = False):
             ]
 
             # Generate response
-            response = model.generate_content(contents)
+            response = model.generate_content(
+                contents, request_options={"timeout": 600}
+            )
             transcription = response.text
 
             # Run analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ dependencies = [
     "unstructured",
     "google-cloud-speech>=2.32.0",
     "google-cloud-storage>=3.1.0",
+    "pymupdf",
+    "validators",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- Implemented parallel processing for PDFs larger than 10 pages to handle context window limitations
- Separated transcription and analysis phases for better performance
- Added progress indicators to show processing status

## Changes
- Split PDFs into 10-page chunks when they exceed 10 pages
- Process chunks in parallel using ThreadPoolExecutor (up to 5 concurrent workers)
- Transcribe each chunk independently, then stitch results together
- Run analysis as a separate phase on the complete transcription
- Added PyMuPDF dependency for PDF manipulation
- Maintain backwards compatibility for smaller PDFs (≤10 pages)

## Test plan
- [ ] Test with a small PDF (≤10 pages) to ensure backwards compatibility
- [ ] Test with a large PDF (>10 pages) to verify parallel processing
- [ ] Verify progress indicators display correctly during processing
- [ ] Confirm analysis runs on the complete transcription
- [ ] Check that page order is maintained in the final output

🤖 Generated with [Claude Code](https://claude.ai/code)