### PR TITLE
feat: add GPT-OSS-120B model and streamline model usage

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -157,7 +157,7 @@ Clearly state if this change breaks existing behavior and what consumers must do
     return prompt
 
 
-async def a_build_commit(oneline: bool = False, fast: bool = False, kimi: bool = True):
+async def a_build_commit(oneline: bool = False, fast: bool = False, kimi: bool = True, gpt_oss: bool = True):
     user_text = "".join(sys.stdin.readlines())
     # Filter out diffs from files that should be skipped
     filtered_text = filter_diff_content(user_text)
@@ -172,10 +172,9 @@ async def a_build_commit(oneline: bool = False, fast: bool = False, kimi: bool =
         llms = langchain_helper.get_models(
             openai=True,
             google=True,
-            o4_mini=True,
             claude=True,
-            openai_mini=True,
             kimi=kimi,
+            gpt_oss=gpt_oss,
         )
         tokens = num_tokens_from_string(filtered_text)
         if tokens < 32_000:
@@ -253,9 +252,12 @@ def build_commit(
     kimi: bool = typer.Option(
         True, "--kimi/--no-kimi", help="Use Kimi model (default: enabled)"
     ),
+    gpt_oss: bool = typer.Option(
+        True, "--gpt-oss/--no-gpt-oss", help="Use GPT-OSS-120B model (default: enabled)"
+    ),
 ):
     def run_build():
-        result = asyncio.run(a_build_commit(oneline, fast, kimi))
+        result = asyncio.run(a_build_commit(oneline, fast, kimi, gpt_oss))
         if result != 0:
             raise typer.Exit(code=result)
 

--- a/langchain_helper.py
+++ b/langchain_helper.py
@@ -99,6 +99,7 @@ def get_models(
     google_think_medium: bool = False,
     google_think_high: bool = False,
     kimi: bool = False,
+    gpt_oss: bool = False,
 ) -> List[BaseChatModel]:
     ret = []
 
@@ -141,6 +142,9 @@ def get_models(
     if kimi:
         ret.append(get_model(kimi=True))
 
+    if gpt_oss:
+        ret.append(get_model(gpt_oss=True))
+
     return ret
 
 
@@ -159,6 +163,7 @@ def get_model(
     google_think_medium: bool = False,
     google_think_high: bool = False,
     kimi: bool = False,
+    gpt_oss: bool = False,
 ) -> BaseChatModel:
     """
     See changes in diff
@@ -178,6 +183,8 @@ def get_model(
             google_think_medium,
             google_think_high,
             kimi,
+            gpt_oss,
+            openai_mini,
         ]
     )
     if count_true > 1:
@@ -286,6 +293,10 @@ def get_model(
         from langchain_groq import ChatGroq
 
         model = ChatGroq(model_name="moonshotai/kimi-k2-instruct")
+    elif gpt_oss:
+        from langchain_groq import ChatGroq
+
+        model = ChatGroq(model_name="openai/gpt-oss-120b")
     elif o4_mini:
         from langchain_openai.chat_models import ChatOpenAI
 

--- a/think.py
+++ b/think.py
@@ -422,6 +422,7 @@ async def a_think(
     core_problems: bool,
     interests: bool,
     kimi: bool,
+    gpt_oss: bool,
 ):
     output_dir = Path("~/tmp").expanduser()
     repo_info = get_repo_info()  # Default False for getting source file URL
@@ -430,12 +431,9 @@ async def a_think(
         openai=True,
         claude=True,
         google=True,
-        google_think=True,
-        deepseek=True,
-        o4_mini=True,
-        google_flash=True,
-        openai_mini=True,
+        google_think_medium=True,
         kimi=kimi,
+        gpt_oss=gpt_oss,
     )
 
     user_text = openai_wrapper.get_text_from_path_or_stdin(path)
@@ -564,6 +562,9 @@ def think(
     kimi: bool = typer.Option(
         True, "--kimi/--no-kimi", help="Use Kimi model (default: enabled)"
     ),
+    gpt_oss: bool = typer.Option(
+        True, "--gpt-oss/--no-gpt-oss", help="Use GPT-OSS-120B model (default: enabled)"
+    ),
     path: str = typer.Argument(None),
 ):
     langchain_helper.langsmith_trace_if_requested(
@@ -576,6 +577,7 @@ def think(
                 core_problems=core_problems,
                 interests=interests,
                 kimi=kimi,
+                gpt_oss=gpt_oss,
             )
         ),
     )


### PR DESCRIPTION
## Summary
- Add OpenAI's GPT-OSS-120B model (latest Groq open source model) to the codebase
- Streamline model selection in think.py and commit.py while keeping all models available in langchain_helper.py

## Changes
- ✅ Added `gpt_oss` parameter to langchain_helper.py for GPT-OSS-120B via Groq API
- ✅ Added `--gpt-oss/--no-gpt-oss` flags to both think.py and commit.py (default: enabled)
- ✅ Removed less effective models from active use in think.py and commit.py (but kept in helper)
- ✅ Models removed from active rotation: deepseek-r1, openai_mini (gpt-4.1-mini), o4_mini, google_flash, google_think_low

## Active Models
The following models are now used by default:
- OpenAI GPT-4
- Google Gemini 2.5 Pro
- Google Gemini 2.5 Flash with MEDIUM thinking
- Claude Sonnet 4
- Kimi K2 via Groq
- **GPT-OSS-120B via Groq (new)**
- Llama 4 Maverick (for smaller contexts)

## Test Plan
- [ ] Run `./think.py` with a test document
- [ ] Run `./commit.py` with a test diff
- [ ] Verify GPT-OSS-120B model is included in outputs
- [ ] Test `--no-gpt-oss` flag works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)