### PR TITLE
feat(transcribe): add YouTube URL support and improved error handling

### DIFF
--- a/transcribe.py
+++ b/transcribe.py
@@ -7,11 +7,13 @@
 #     "rich",
 #     "icecream",
 #     "assemblyai",
+#     "yt-dlp",
 # ]
 # ///
 
 from datetime import datetime
 import typer
+import subprocess
 
 from loguru import logger
 from rich import print
@@ -24,14 +26,55 @@ import os
 app = typer.Typer(no_args_is_help=True)
 
 
+def get_youtube_audio_url(youtube_url: str) -> str:
+    """Extract audio URL from YouTube video using yt-dlp"""
+    try:
+        result = subprocess.run([
+            "yt-dlp",
+            "--get-url",
+            "-f", "bestaudio",
+            youtube_url
+        ], capture_output=True, text=True, check=True)
+
+        audio_url = result.stdout.strip()
+        print(f"Extracted audio URL: {audio_url[:100]}...")
+        return audio_url
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to extract audio URL: {e}")
+        return None
+
+
 @app.command()
 def transcribe(
-    path: Path = typer.Argument(None), diarization: bool = True, srt: bool = False
+    path: Path = typer.Argument(None),
+    url: str = typer.Option(None, help="YouTube URL to transcribe"),
+    diarization: bool = True,
+    srt: bool = False
 ):
     aai.settings.api_key = os.environ.get("ASSEMBLYAI_API_KEY")
 
-    default_audio_url = "https://github.com/AssemblyAI-Community/audio-examples/raw/main/20230607_me_canadian_wildfires.mp3"
-    audio_url = path.open("rb") if path else default_audio_url
+    if not aai.settings.api_key:
+        print("Please set ASSEMBLYAI_API_KEY environment variable")
+        print("Get your API key from: https://www.assemblyai.com/")
+        return
+
+    if url:
+        # Handle YouTube URL
+        if "youtube.com" in url or "youtu.be" in url:
+            print("Extracting audio URL from YouTube...")
+            audio_url = get_youtube_audio_url(url)
+            if not audio_url:
+                print("Failed to extract audio URL from YouTube")
+                return
+        else:
+            # Direct audio URL
+            audio_url = url
+    elif path:
+        # Handle local file
+        audio_url = path.open("rb")
+    else:
+        # Default example
+        audio_url = "https://github.com/AssemblyAI-Community/audio-examples/raw/main/20230607_me_canadian_wildfires.mp3"
 
     config = aai.TranscriptionConfig(speaker_labels=diarization)
 
@@ -39,8 +82,16 @@ def transcribe(
     transcript = aai.Transcriber().transcribe(audio_url, config)
     ic(transcript)
 
-    for utterance in transcript.utterances:
-        print(f"Speaker {utterance.speaker}: {utterance.text}")
+    if transcript.status == aai.TranscriptStatus.error:
+        print(f"Transcription failed: {transcript.error}")
+        return
+
+    if transcript.utterances:
+        for utterance in transcript.utterances:
+            print(f"Speaker {utterance.speaker}: {utterance.text}")
+    else:
+        print("No utterances found in transcript")
+        print(f"Full transcript text: {transcript.text}")
 
     if srt:
         print(transcript.export_subtitles_srt())


### PR DESCRIPTION
## Summary
- Add YouTube URL support with yt-dlp integration for direct video transcription  
- Improve error handling and user experience with better API key validation
- Support both local files and YouTube URLs seamlessly

## Changes
- Add `yt-dlp` to script dependencies for YouTube audio extraction
- Add `--url` flag to accept YouTube URLs directly
- Implement `get_youtube_audio_url()` function for audio stream extraction
- Add comprehensive error handling for failed transcriptions
- Improve API key validation with helpful user guidance
- Better transcript output handling for edge cases

## Test Plan
- [x] Test YouTube URL extraction with yt-dlp
- [x] Test error handling without API key  
- [x] Test script runs standalone with all dependencies
- [x] Verify backward compatibility with existing file-based usage

🤖 Generated with [Claude Code](https://claude.ai/code)